### PR TITLE
Changed muting logic to ignore plugged-in headphones

### DIFF
--- a/DeltaCore/Emulator Core/Audio/AudioManager.swift
+++ b/DeltaCore/Emulator Core/Audio/AudioManager.swift
@@ -376,14 +376,14 @@ private extension AudioManager
         else
         {
             let route = AVAudioSession.sharedInstance().currentRoute
-            if self.isMuted && (route.isHeadsetPluggedIn || !route.isOutputtingToExternalDevice)
+            if self.isMuted && !route.isOutputtingToExternalDevice
             {
-                // Mute if playing through speaker or headphones.
+                // Mute if playing through device speakers.
                 self.audioEngine.mainMixerNode.outputVolume = 0.0
             }
             else
             {
-                // Ignore mute switch for other audio routes (e.g. AirPlay).
+                // Ignore mute switch for other audio routes (e.g. AirPlay, headphones).
                 self.audioEngine.mainMixerNode.outputVolume = 1.0
             }
         }


### PR DESCRIPTION
This PR changes the audio logic to _not_ mute the audio when it's detected that headphones are plugged in. This brings the behaviour in line with the system standard for apps with "optional" audio.

That being said, in order to give users the most flexibility, moving forward, we'll put the original behaviour back in as a toggle switch option in the Settings screen.